### PR TITLE
PropertyTypeInfo introduced

### DIFF
--- a/DevExtreme.AspNet.TagHelpers.Generator/ClassBuilder.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/ClassBuilder.cs
@@ -131,7 +131,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             AppendEmptyLine();
         }
 
-        public void AppendProp(TagPropertyInfo prop) {
+        public void AppendProp(TagPropertyInfo prop, PropertyTypeInfo propType) {
             AppendSummary(prop.GetSummaryText());
 
             var customAttr = prop.GetCustomAttrName();
@@ -139,22 +139,20 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
                 AppendAttribute("HtmlAttributeName", $"\"{customAttr}\"");
 
             var name = prop.GetName();
-            var dirtyType = prop.GetClrType();
-            var type = PropTypeRegistry.StripSpecialType(dirtyType);
 
             AppendGeneratedAttribute();
-            Append($"public {type} {name} ");
+            Append($"public {propType.ClrType} {name} ");
             StartBlock();
 
-            AppendLine($"get {{ return GetConfigValue<{type}>(\"{name}\"); }}");
+            AppendLine($"get {{ return GetConfigValue<{propType.ClrType}>(\"{name}\"); }}");
             Append($"set {{ SetConfigValue(\"{name}\", ");
 
-            if(dirtyType == PropTypeRegistry.SPECIAL_DOM_TEMPLATE)
+            if(propType.IsDomTemplate)
                 Append("Utils.WrapDomTemplateValue(value)");
             else
                 Append("value");
 
-            if(dirtyType == PropTypeRegistry.SPECIAL_RAW_STRING || dirtyType == PropTypeRegistry.SPECIAL_DOM_TEMPLATE)
+            if(propType.IsRawString)
                 Append(", isRaw: true");
 
             AppendLine("); }");

--- a/DevExtreme.AspNet.TagHelpers.Generator/Generator.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/Generator.cs
@@ -58,8 +58,10 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             }
 
             foreach(var prop in tag.GenerateProperties()) {
-                CompetitivePropsRegistry.Register(tag.GetFullKey() + "." + prop.GetName(), prop.GetClrType());
-                builder.AppendProp(prop);
+                var propTypeInfo = new PropertyTypeInfo(tag.GetFullKey(), prop.GetName(), prop.GetJsType());
+
+                CompetitivePropsRegistry.Register(tag.GetFullKey() + "." + prop.GetName(), propTypeInfo.ClrType);
+                builder.AppendProp(prop, propTypeInfo);
             }
 
             builder.EndBlock();

--- a/DevExtreme.AspNet.TagHelpers.Generator/PropTypeRegistry.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/PropTypeRegistry.cs
@@ -6,99 +6,79 @@ using System.Threading.Tasks;
 namespace DevExtreme.AspNet.TagHelpers.Generator {
 
     static class PropTypeRegistry {
-        public const string CLR_TYPE_OVERRIDE_ATTR = "ClrTypeOverride";
-
-        public const string
-            CLR_BOOL = "bool",
-            CLR_DOUBLE = "double",
-            CLR_STRING = "string",
-            CLR_DATE = "DateTime",
-            CLR_OBJECT = "object",
-            CLR_ARRAY_STRING = "IEnumerable<string>",
-            CLR_ARRAY_OBJECT = "IEnumerable<object>",
-
-            SPECIAL_RAW_STRING = "sp_raw_string",
-            SPECIAL_DOM_TEMPLATE = "sp_dom_template";
 
         public static readonly IDictionary<string, string> OverrideTable = new Dictionary<string, string> {
-            { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Field.FilterValues", CLR_ARRAY_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Field.SortBySummaryPath", CLR_ARRAY_STRING },
-            { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Filter", CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Field.FilterValues", PropertyTypeInfo.CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Field.SortBySummaryPath", PropertyTypeInfo.CLR_ARRAY_STRING },
+            { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Filter", PropertyTypeInfo.CLR_ARRAY_OBJECT },
 
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Categories", CLR_ARRAY_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.ConstantLine.Value", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Max", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Min", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.MinorTickInterval", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Strip.EndValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Strip.StartValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.TickInterval", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.CommonSeriesSettings.Label.Position", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.DataPrepareSettings.SortingMethod", CLR_BOOL },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.Series.Label.Position", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.Tooltip.Container", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Categories", CLR_ARRAY_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.ConstantLine.Value", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Max", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Min", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.MinorTickInterval", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Strip.EndValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Strip.StartValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.TickInterval", CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Categories", PropertyTypeInfo.CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.ConstantLine.Value", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Max", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Min", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.MinorTickInterval", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Strip.EndValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.Strip.StartValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ArgumentAxis.TickInterval", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.CommonSeriesSettings.Label.Position", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.DataPrepareSettings.SortingMethod", PropertyTypeInfo.CLR_BOOL },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.Series.Label.Position", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.Tooltip.Container", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Categories", PropertyTypeInfo.CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.ConstantLine.Value", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Max", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Min", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.MinorTickInterval", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Strip.EndValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.Strip.StartValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxChart.ValueAxis.TickInterval", PropertyTypeInfo.CLR_OBJECT },
 
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateCellValue", SPECIAL_RAW_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateDisplayValue", SPECIAL_RAW_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateGroupValue", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateSortValue", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.EditorOptions", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.FilterValues", CLR_ARRAY_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.FormItem", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.Lookup.DisplayExpr", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.ValidationRules", CLR_ARRAY_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Editing.Form", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.FilterRow.OperationDescriptions", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Height", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Pager.AllowedPageSizes", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Pager.Visible", CLR_BOOL },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Scrolling.UseNative", CLR_BOOL },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.SelectedRowKeys", CLR_ARRAY_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Width", CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateCellValue", PropertyTypeInfo.SPECIAL_RAW_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateDisplayValue", PropertyTypeInfo.SPECIAL_RAW_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateGroupValue", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.CalculateSortValue", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.EditorOptions", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.FilterValues", PropertyTypeInfo.CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.FormItem", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.Lookup.DisplayExpr", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Column.ValidationRules", PropertyTypeInfo.CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Editing.Form", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.FilterRow.OperationDescriptions", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Height", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Pager.AllowedPageSizes", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Pager.Visible", PropertyTypeInfo.CLR_BOOL },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Scrolling.UseNative", PropertyTypeInfo.CLR_BOOL },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.SelectedRowKeys", PropertyTypeInfo.CLR_ARRAY_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxDataGrid.Width", PropertyTypeInfo.CLR_STRING },
 
-            { "DevExtreme.AspNet.TagHelpers.dxPieChart.CommonSeriesSettings.Label.Position", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxPieChart.Series.Label.Position", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxPieChart.Tooltip.Container", CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxPieChart.CommonSeriesSettings.Label.Position", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxPieChart.Series.Label.Position", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxPieChart.Tooltip.Container", PropertyTypeInfo.CLR_STRING },
 
-            { "DevExtreme.AspNet.TagHelpers.dxPivotGrid.Height", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxPivotGrid.Scrolling.UseNative", CLR_BOOL },
-            { "DevExtreme.AspNet.TagHelpers.dxPivotGrid.Width", CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxPivotGrid.Height", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxPivotGrid.Scrolling.UseNative", PropertyTypeInfo.CLR_BOOL },
+            { "DevExtreme.AspNet.TagHelpers.dxPivotGrid.Width", PropertyTypeInfo.CLR_STRING },
 
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Chart.CommonSeriesSettings.Label.Position", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Chart.DataPrepareSettings.SortingMethod", CLR_BOOL },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Chart.Series.Label.Position", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.Categories", CLR_ARRAY_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.EndValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.TickInterval", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.MinorTickInterval", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.StartValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.SelectedRange.EndValue", CLR_OBJECT },
-            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.SelectedRange.StartValue", CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Chart.CommonSeriesSettings.Label.Position", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Chart.DataPrepareSettings.SortingMethod", PropertyTypeInfo.CLR_BOOL },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Chart.Series.Label.Position", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.Categories", PropertyTypeInfo.CLR_ARRAY_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.EndValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.TickInterval", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.MinorTickInterval", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.Scale.StartValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.SelectedRange.EndValue", PropertyTypeInfo.CLR_OBJECT },
+            { "DevExtreme.AspNet.TagHelpers.dxRangeSelector.SelectedRange.StartValue", PropertyTypeInfo.CLR_OBJECT },
 
-            { "DevExtreme.AspNet.TagHelpers.dxScheduler.CurrentDate", CLR_DATE },
-            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Groups", CLR_ARRAY_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Height", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Resource.DisplayExpr", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Resource.ValueExpr", CLR_STRING },
-            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Width", CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxScheduler.CurrentDate", PropertyTypeInfo.CLR_DATE },
+            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Groups", PropertyTypeInfo.CLR_ARRAY_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Height", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Resource.DisplayExpr", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Resource.ValueExpr", PropertyTypeInfo.CLR_STRING },
+            { "DevExtreme.AspNet.TagHelpers.dxScheduler.Width", PropertyTypeInfo.CLR_STRING },
 
-            { "DevExtreme.AspNet.TagHelpers.dxSparkline.Tooltip.Container", CLR_STRING }
+            { "DevExtreme.AspNet.TagHelpers.dxSparkline.Tooltip.Container", PropertyTypeInfo.CLR_STRING }
         };
-
-
-        public static string StripSpecialType(string type) {
-            if(type == SPECIAL_DOM_TEMPLATE || type == SPECIAL_RAW_STRING)
-                return CLR_STRING;
-            return type;
-        }
-
     }
+
 }

--- a/DevExtreme.AspNet.TagHelpers.Generator/PropertyTypeInfo.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/PropertyTypeInfo.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace DevExtreme.AspNet.TagHelpers.Generator {
+
+    public class PropertyTypeInfo {
+        public const string
+            CLR_BOOL = "bool",
+            CLR_DOUBLE = "double",
+            CLR_STRING = "string",
+            CLR_DATE = "DateTime",
+            CLR_OBJECT = "object",
+            CLR_ARRAY_STRING = "IEnumerable<string>",
+            CLR_ARRAY_OBJECT = "IEnumerable<object>",
+
+            SPECIAL_RAW_STRING = "sp_raw_string",
+            SPECIAL_DOM_TEMPLATE = "sp_dom_template";
+
+
+        public readonly string ClrType;
+        public readonly bool IsDomTemplate;
+        public readonly bool IsRawString;
+
+        public PropertyTypeInfo(string tagFullKey, string propName, string jsTypeString) {
+            var dirtyType =
+                TryGetTypeOverride(tagFullKey + "." + propName, isArray: jsTypeString == "array") ??
+                TryGetType(propName, jsTypeString);
+
+            if(dirtyType == null)
+                throw new Exception("Unable to resolve property type");
+
+            IsDomTemplate = dirtyType == SPECIAL_DOM_TEMPLATE;
+            IsRawString = dirtyType == SPECIAL_RAW_STRING || dirtyType == SPECIAL_DOM_TEMPLATE;
+            ClrType = StripSpecialType(dirtyType);
+        }
+
+        static string TryGetType(string propName, string jsTypeString) {
+            var rawTypes = jsTypeString.Split('|');
+            bool
+                canBeString = rawTypes.Any(t => t == "string"),
+                canBeNumber = rawTypes.Any(t => t == "number" || t == "numeric"),
+                canBeBool = rawTypes.Any(t => t == "bool" || t == "boolean"),
+                canDeDate = rawTypes.Any(t => t == "date"),
+                canBeFunc = rawTypes.Any(t => t.StartsWith("function")),
+                canBeJQuery = rawTypes.Any(t => t == "jquery"),
+                canBeAny = rawTypes.Any(t => t == "any");
+
+            if(rawTypes.Length == 1) {
+                if(canBeString)
+                    return CLR_STRING;
+
+                if(canBeBool)
+                    return CLR_BOOL;
+
+                if(canBeNumber)
+                    return CLR_DOUBLE;
+
+                if(canBeFunc)
+                    return SPECIAL_RAW_STRING;
+
+                if(canBeAny)
+                    return CLR_OBJECT;
+
+                if(canDeDate)
+                    return CLR_DATE;
+            }
+
+            if(rawTypes.Length == 2) {
+                if(canBeString && canBeNumber)
+                    return CLR_STRING;
+
+                if(canBeFunc && canBeString && Regex.IsMatch(propName, "^On[A-Z]"))
+                    return SPECIAL_RAW_STRING;
+            }
+
+            if(canBeFunc && canBeJQuery)
+                return SPECIAL_DOM_TEMPLATE;
+
+            return null;
+        }
+
+        static string TryGetTypeOverride(string fullName, bool isArray) {
+            if(PropTypeRegistry.OverrideTable.ContainsKey(fullName))
+                return PropTypeRegistry.OverrideTable[fullName];
+
+            if(EnumRegistry.InvertedKnownEnumns.ContainsKey(fullName))
+                return isArray
+                    ? $"IEnumerable<{EnumRegistry.InvertedKnownEnumns[fullName]}>"
+                    : EnumRegistry.InvertedKnownEnumns[fullName];
+
+            return null;
+        }
+
+        static string StripSpecialType(string type) {
+            if(type == SPECIAL_DOM_TEMPLATE || type == SPECIAL_RAW_STRING)
+                return CLR_STRING;
+
+            return type;
+        }
+    }
+
+}

--- a/DevExtreme.AspNet.TagHelpers.Generator/TagInfoPreProcessor.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/TagInfoPreProcessor.cs
@@ -18,7 +18,6 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             ModifyCommonSeriesSettings(tag);
             TurnChildrenIntoProps(tag);
             ValidateEnums(tag);
-            ModifyPropTypes(tag);
         }
 
         static void ModifyWidget(TagInfo tag) {
@@ -160,29 +159,6 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
                     continue;
 
                 EnumRegistry.ValidateEnum(propElement, tag.GetFullKey());
-            }
-        }
-
-        static void ModifyPropTypes(TagInfo tag) {
-            var enumsTable = EnumRegistry.InvertedKnownEnumns;
-            var propsTable = PropTypeRegistry.OverrideTable;
-
-            foreach(var propElement in tag.PropElements) {
-                var fullName = tag.GetFullKey() + "." + Utils.ToCamelCase(propElement.GetName());
-                var overridenType = String.Empty;
-
-                if(enumsTable.ContainsKey(fullName)) {
-                    if(propElement.GetRawType() == "array")
-                        overridenType = $"IEnumerable<{enumsTable[fullName]}>";
-                    else
-                        overridenType = enumsTable[fullName];
-                }
-
-                if(propsTable.ContainsKey(fullName))
-                    overridenType = propsTable[fullName];
-
-                if(!String.IsNullOrEmpty(overridenType))
-                    propElement.SetAttributeValue(PropTypeRegistry.CLR_TYPE_OVERRIDE_ATTR, overridenType);
             }
         }
     }

--- a/DevExtreme.AspNet.TagHelpers.Generator/TagPropertyInfo.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/TagPropertyInfo.cs
@@ -22,55 +22,8 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             return Utils.NormalizeDescription(_element.GetDescription());
         }
 
-        public string GetClrType() {
-            var clrOverride = _element.Attribute(PropTypeRegistry.CLR_TYPE_OVERRIDE_ATTR)?.Value;
-            if(!String.IsNullOrEmpty(clrOverride))
-                return clrOverride;
-
-            var rawTypes = _element.GetRawType().Split('|');
-            var name = GetName();
-
-            bool
-                canBeString = rawTypes.Any(t => t == "string"),
-                canBeNumber = rawTypes.Any(t => t == "number" || t == "numeric"),
-                canBeBool = rawTypes.Any(t => t == "bool" || t == "boolean"),
-                canDeDate = rawTypes.Any(t => t == "date"),
-                canBeFunc = rawTypes.Any(t => t.StartsWith("function")),
-                canBeJQuery = rawTypes.Any(t => t == "jquery"),
-                canBeAny = rawTypes.Any(t => t == "any");
-
-            if(rawTypes.Length == 1) {
-                if(canBeString)
-                    return PropTypeRegistry.CLR_STRING;
-
-                if(canBeBool)
-                    return PropTypeRegistry.CLR_BOOL;
-
-                if(canBeNumber)
-                    return PropTypeRegistry.CLR_DOUBLE;
-
-                if(canBeFunc)
-                    return PropTypeRegistry.SPECIAL_RAW_STRING;
-
-                if(canBeAny)
-                    return PropTypeRegistry.CLR_OBJECT;
-
-                if(canDeDate)
-                    return PropTypeRegistry.CLR_DATE;
-            }
-
-            if(rawTypes.Length == 2) {
-                if(canBeString && canBeNumber)
-                    return PropTypeRegistry.CLR_STRING;
-
-                if(canBeFunc && canBeString && Regex.IsMatch(name, "^On[A-Z]"))
-                    return PropTypeRegistry.SPECIAL_RAW_STRING;
-            }
-
-            if(canBeFunc && canBeJQuery)
-                return PropTypeRegistry.SPECIAL_DOM_TEMPLATE;
-
-            throw new Exception("Unable to resolve property type");
+        public string GetJsType() {
+            return _element.GetRawType();
         }
 
         public string GetCustomAttrName() {
@@ -79,7 +32,6 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
                 return "data" + Utils.ToKebabCase(name.Substring(4));
             return null;
         }
-
     }
 
 }


### PR DESCRIPTION
All property type definition methods come now together: `PropertyTypeInfo` class is responsible for providing the Generator with info about property CLR type, whether it is a DOM template or a raw-string.