### PR TITLE
Enum validation joined with Enum type resolving

### DIFF
--- a/DevExtreme.AspNet.TagHelpers.Generator/EnumRegistry.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/EnumRegistry.cs
@@ -25,15 +25,16 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             }
         }
 
-        public static bool SuspectEnum(XElement element) {
-            return element.Element("Values").Elements().Any();
+        public static bool IsEnum(XElement element, string fullName) {
+            return !KnownNonEnums.Contains(fullName) && element.Element("Values").Elements().Any();
         }
 
-        public static void ValidateEnum(XElement element, string parentFullKey) {
-            var fullName = parentFullKey + "." + Utils.ToCamelCase(element.GetName());
+        public static string GetEnumTypeName(XElement element, string fullName) {
+            ValidateEnum(element, fullName);
+            return InvertedKnownEnumns[fullName];
+        }
 
-            if(KnownNonEnums.Contains(fullName))
-                return;
+        static void ValidateEnum(XElement element, string fullName) {
 
             var intellisenseValues = element.Element("Values").Elements()
                 .Select(i => i.GetName().Trim())

--- a/DevExtreme.AspNet.TagHelpers.Generator/Generator.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/Generator.cs
@@ -58,7 +58,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             }
 
             foreach(var prop in tag.GenerateProperties()) {
-                var propTypeInfo = prop.GetTypeInfo(tag.GetFullKey());
+                var propTypeInfo = prop.CreateTypeInfo(tag.GetFullKey());
 
                 CompetitivePropsRegistry.Register(tag.GetFullKey() + "." + prop.GetName(), propTypeInfo.ClrType);
                 builder.AppendProp(prop, propTypeInfo);

--- a/DevExtreme.AspNet.TagHelpers.Generator/Generator.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/Generator.cs
@@ -58,7 +58,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             }
 
             foreach(var prop in tag.GenerateProperties()) {
-                var propTypeInfo = new PropTypeInfo(tag.GetFullKey(), prop.GetName(), prop.GetRawType());
+                var propTypeInfo = prop.GetTypeInfo(tag.GetFullKey());
 
                 CompetitivePropsRegistry.Register(tag.GetFullKey() + "." + prop.GetName(), propTypeInfo.ClrType);
                 builder.AppendProp(prop, propTypeInfo);

--- a/DevExtreme.AspNet.TagHelpers.Generator/PropTypeInfo.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/PropTypeInfo.cs
@@ -29,7 +29,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
         public PropTypeInfo(XElement element, string fullName, string propName) {
             var rawType = element.GetRawType();
             var dirtyType =
-                TryGetPredefinedType(fullName) ??
+                TryGetTypeOverride(fullName) ??
                 TryGetEnumType(element, fullName, isArray: rawType == "array") ??
                 TryGetType(propName, rawType);
 
@@ -86,7 +86,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             return null;
         }
 
-        static string TryGetPredefinedType(string fullName) {
+        static string TryGetTypeOverride(string fullName) {
             if(_overrideTable.ContainsKey(fullName))
                 return _overrideTable[fullName];
 

--- a/DevExtreme.AspNet.TagHelpers.Generator/PropTypeInfo.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/PropTypeInfo.cs
@@ -20,7 +20,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             SPECIAL_RAW_STRING = "sp_raw_string",
             SPECIAL_DOM_TEMPLATE = "sp_dom_template";
 
-        static readonly IDictionary<string, string> _predefinedTypes = InitPredefinedTypes();
+        static readonly IDictionary<string, string> _overrideTable = InitOverrideTable();
 
         public readonly string ClrType;
         public readonly bool IsDomTemplate;
@@ -87,8 +87,8 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
         }
 
         static string TryGetPredefinedType(string fullName) {
-            if(_predefinedTypes.ContainsKey(fullName))
-                return _predefinedTypes[fullName];
+            if(_overrideTable.ContainsKey(fullName))
+                return _overrideTable[fullName];
 
             return null;
         }
@@ -111,7 +111,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             return type;
         }
 
-        static IDictionary<string, string> InitPredefinedTypes() => new Dictionary<string, string> {
+        static IDictionary<string, string> InitOverrideTable() => new Dictionary<string, string> {
             { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Field.FilterValues", CLR_ARRAY_OBJECT },
             { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Field.SortBySummaryPath", CLR_ARRAY_STRING },
             { "DevExtreme.AspNet.TagHelpers.Data.Datasource.Filter", CLR_ARRAY_OBJECT },

--- a/DevExtreme.AspNet.TagHelpers.Generator/TagInfoPreProcessor.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/TagInfoPreProcessor.cs
@@ -17,7 +17,6 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             ModifyRangeSelectorChartOptions(tag);
             ModifyCommonSeriesSettings(tag);
             TurnChildrenIntoProps(tag);
-            ValidateEnums(tag);
         }
 
         static void ModifyWidget(TagInfo tag) {
@@ -150,15 +149,6 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
                 element.Element("Properties").Remove();
                 tag.ChildTagElements.Remove(element);
                 tag.PropElements.Add(element);
-            }
-        }
-
-        static void ValidateEnums(TagInfo tag) {
-            foreach(var propElement in tag.PropElements) {
-                if(!EnumRegistry.SuspectEnum(propElement))
-                    continue;
-
-                EnumRegistry.ValidateEnum(propElement, tag.GetFullKey());
             }
         }
     }

--- a/DevExtreme.AspNet.TagHelpers.Generator/TagPropertyInfo.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/TagPropertyInfo.cs
@@ -22,6 +22,13 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             return Utils.NormalizeDescription(_element.GetDescription());
         }
 
+        public PropTypeInfo GetTypeInfo(string parentName) {
+            var propName = GetName();
+            var fullName = $"{parentName}.{propName}";
+
+            return new PropTypeInfo(_element, fullName, propName);
+        }
+
         public string GetRawType() {
             return _element.GetRawType();
         }

--- a/DevExtreme.AspNet.TagHelpers.Generator/TagPropertyInfo.cs
+++ b/DevExtreme.AspNet.TagHelpers.Generator/TagPropertyInfo.cs
@@ -22,7 +22,7 @@ namespace DevExtreme.AspNet.TagHelpers.Generator {
             return Utils.NormalizeDescription(_element.GetDescription());
         }
 
-        public PropTypeInfo GetTypeInfo(string parentName) {
+        public PropTypeInfo CreateTypeInfo(string parentName) {
             var propName = GetName();
             var fullName = $"{parentName}.{propName}";
 


### PR DESCRIPTION
These two actions (**Enum type validating** and **Enum type resolving**) should go coupled to ensure methods are called in the right order and prevent wrong validation failures (if `Enum` type is not required).