### PR TITLE
Generate XML Doc file on build

### DIFF
--- a/DevExtreme.AspNet.TagHelpers/project.json
+++ b/DevExtreme.AspNet.TagHelpers/project.json
@@ -10,6 +10,11 @@
         "projectUrl": "%meta_project_url%"
     },
 
+    "buildOptions": {
+        "nowarn": [ "1591" ],
+        "xmlDoc": true
+    },
+
     "dependencies": {
         "Microsoft.AspNetCore.Mvc.Core": "1.0.0",
         "Microsoft.AspNetCore.Mvc.Formatters.Json": "1.0.0",


### PR DESCRIPTION
Currently, NuGet packages don't include XML documentation.
This PR fixes that.
