### PR TITLE
Remove the use of the Data namespace

### DIFF
--- a/DevExtreme.AspNet.TagHelpers/DevExtreme.AspNet.Data.Portions.cs
+++ b/DevExtreme.AspNet.TagHelpers/DevExtreme.AspNet.Data.Portions.cs
@@ -1,37 +1,37 @@
-﻿using DevExtreme.AspNet.Data.Helpers;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
-using Microsoft.Net.Http.Headers;
-using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using DevExtreme.AspNet.Data;
+using DevExtreme.AspNet.Data.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 
-namespace DevExtreme.AspNet.Data {
-
+namespace DevExtreme.AspNet.TagHelpers
+{
     [ModelBinder(BinderType = typeof(DataSourceLoadOptionsBinder))]
-    public class DataSourceLoadOptions : DataSourceLoadOptionsBase {
+    public class DataSourceLoadOptions : DataSourceLoadOptionsBase
+    {
     }
 
-    public class DataSourceLoadOptionsBinder : IModelBinder {
+    public class DataSourceLoadOptionsBinder : IModelBinder
+    {
 
-        public Task BindModelAsync(ModelBindingContext bindingContext) {
+        public Task BindModelAsync(ModelBindingContext bindingContext)
+        {
             var loadOptions = new DataSourceLoadOptions();
             DataSourceLoadOptionsParser.Parse(loadOptions, key => bindingContext.ValueProvider.GetValue(key).FirstOrDefault());
             bindingContext.Result = ModelBindingResult.Success(loadOptions);
-            return Task.CompletedTask;
+            return null;
         }
-
     }
 
     [Obsolete("This attribute is now obsolete and is no longer used. It was used as a workaround for the issue discussed at https://github.com/aspnet/Mvc/issues/4652")]
-    public class DataSourceLoadOptionsAttribute : ModelBinderAttribute {
+    public class DataSourceLoadOptionsAttribute : ModelBinderAttribute
+    {
 
-        public DataSourceLoadOptionsAttribute() {
+        public DataSourceLoadOptionsAttribute()
+        {
             BinderType = typeof(DataSourceLoadOptionsBinder);
         }
-
     }
-
 }

--- a/DevExtreme.AspNet.TagHelpers/DevExtreme.AspNet.Data.Portions.cs
+++ b/DevExtreme.AspNet.TagHelpers/DevExtreme.AspNet.Data.Portions.cs
@@ -1,37 +1,38 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
-using DevExtreme.AspNet.Data;
+﻿using DevExtreme.AspNet.Data;
 using DevExtreme.AspNet.Data.Helpers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Net.Http.Headers;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
-namespace DevExtreme.AspNet.TagHelpers
-{
+namespace DevExtreme.AspNet.TagHelpers {
+
     [ModelBinder(BinderType = typeof(DataSourceLoadOptionsBinder))]
-    public class DataSourceLoadOptions : DataSourceLoadOptionsBase
-    {
+    public class DataSourceLoadOptions : DataSourceLoadOptionsBase {
     }
 
-    public class DataSourceLoadOptionsBinder : IModelBinder
-    {
+    public class DataSourceLoadOptionsBinder : IModelBinder {
 
-        public Task BindModelAsync(ModelBindingContext bindingContext)
-        {
+        public Task BindModelAsync(ModelBindingContext bindingContext) {
             var loadOptions = new DataSourceLoadOptions();
             DataSourceLoadOptionsParser.Parse(loadOptions, key => bindingContext.ValueProvider.GetValue(key).FirstOrDefault());
             bindingContext.Result = ModelBindingResult.Success(loadOptions);
-            return null;
+            return Task.CompletedTask;
         }
+
     }
 
     [Obsolete("This attribute is now obsolete and is no longer used. It was used as a workaround for the issue discussed at https://github.com/aspnet/Mvc/issues/4652")]
-    public class DataSourceLoadOptionsAttribute : ModelBinderAttribute
-    {
+    public class DataSourceLoadOptionsAttribute : ModelBinderAttribute {
 
-        public DataSourceLoadOptionsAttribute()
-        {
+        public DataSourceLoadOptionsAttribute() {
             BinderType = typeof(DataSourceLoadOptionsBinder);
         }
+
     }
+
 }

--- a/DevExtreme.AspNet.TagHelpers/project.json
+++ b/DevExtreme.AspNet.TagHelpers/project.json
@@ -18,9 +18,14 @@
         "DevExtreme.AspNet.Data": "1.0.0"
     },
 
-    "frameworks": {
-        "netstandard1.6": {
-            "imports": [ "dotnet" ]
-        }
+  "frameworks": {
+    "net451": {
+      "frameworkAssemblies": {
+        "System.Runtime.Serialization": "4.0.0.0"
+      }
+    },
+    "netstandard1.6": {
+      "imports": [ "dotnet" ]
     }
+  }
 }

--- a/DevExtreme.AspNet.TagHelpers/project.json
+++ b/DevExtreme.AspNet.TagHelpers/project.json
@@ -18,14 +18,9 @@
         "DevExtreme.AspNet.Data": "1.0.0"
     },
 
-  "frameworks": {
-    "net451": {
-      "frameworkAssemblies": {
-        "System.Runtime.Serialization": "4.0.0.0"
-      }
-    },
-    "netstandard1.6": {
-      "imports": [ "dotnet" ]
+    "frameworks": {
+        "netstandard1.6": {
+            "imports": [ "dotnet" ]
+        }
     }
-  }
 }

--- a/Samples/Controllers/GoogleCalendarController.cs
+++ b/Samples/Controllers/GoogleCalendarController.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
+using DevExtreme.AspNet.TagHelpers;
 
 namespace Samples.Controllers {
 

--- a/Samples/Controllers/NorthwindController.cs
+++ b/Samples/Controllers/NorthwindController.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using DevExtreme.AspNet.TagHelpers;
 
 namespace Samples.Controllers {
 


### PR DESCRIPTION
Reasons:
- It is not good generally to use foreign namespaces
- If used, they may cause conflicts similar to one reported in https://www.devexpress.com/Support/Center/Question/Details/T413575

Negative effects:
- Causes a breaking change
